### PR TITLE
Updated README, fix for using without configuration

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ And update your bundle with <tt>bundle install</tt>
 
 To be able to use the gem, you must first configure it. If you're on Rails, insert the following code in <tt>config/initializers/sisow.rb</tt>:
 
-  Sisow.setup do |config|
+  Sisow.configure do |config|
     config.merchant_key = 'your-merchant-key'
     config.merchant_id  = 'your-merchant-id'
 

--- a/lib/sisow/api/request.rb
+++ b/lib/sisow/api/request.rb
@@ -38,7 +38,7 @@ module Sisow
       private
 
         def can_perform?
-          !Sisow.configuration.merchant_id.empty? && !Sisow.configuration.merchant_key.empty?
+          !(Sisow.configuration.merchant_id.nil? || Sisow.configuration.merchant_id.empty?) && !(Sisow.configuration.merchant_key.nil? || Sisow.configuration.merchant_key.empty?)
         end
 
         def uri


### PR DESCRIPTION
I've updated documentation to use `Sisow.configure`. 

When using the `Sisow.setup` from the README, the configuration object remains `nil`. `Request#can_perform?`does not appreciate that and throws a `NoMethodError` while evaluating `nil.empty?`. I've added a fix for that too.
