### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    sisow (1.4)
-      crack
-      hashie
-      httpi
+    sisow (1.5)
+      crack (= 0.3.2)
+      hashie (= 1.2.0)
+      httpi (= 2.4.2)
 
 GEM
   remote: http://rubygems.org/
@@ -13,10 +13,11 @@ GEM
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
     hashie (1.2.0)
-    httpi (2.0.0)
+    httpi (2.4.2)
       rack
+      socksify
     multi_json (1.3.5)
-    rack (1.4.4)
+    rack (1.6.4)
     rake (0.9.2.2)
     rspec (2.10.0)
       rspec-core (~> 2.10.0)
@@ -32,16 +33,20 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    socksify (1.7.0)
     vcr (2.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  fakeweb
+  fakeweb (= 1.3.0)
   rake
-  rspec
-  simplecov
-  simplecov-rcov
+  rspec (= 2.10.0)
+  simplecov (= 0.6.4)
+  simplecov-rcov (= 0.2.3)
   sisow!
-  vcr
+  vcr (= 2.1.1)
+
+BUNDLED WITH
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,15 @@ PATH
   remote: .
   specs:
     sisow (1.5)
-      crack (= 0.3.2)
+      crack (= 0.4.3)
       hashie (= 1.2.0)
       httpi (= 2.4.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    crack (0.3.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.1.3)
     fakeweb (1.3.0)
     hashie (1.2.0)
@@ -27,6 +28,7 @@ GEM
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
+    safe_yaml (1.0.4)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)

--- a/sisow.gemspec
+++ b/sisow.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httpi', '2.4.2'
   s.add_dependency 'hashie', '1.2.0'
-  s.add_dependency 'crack', '0.3.2'
+  s.add_dependency 'crack', '0.4.3'
 
   s.add_development_dependency 'rspec', '2.10.0'
   s.add_development_dependency 'vcr', '2.1.1'

--- a/sisow.gemspec
+++ b/sisow.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'httpi'
-  s.add_dependency 'hashie'
-  s.add_dependency 'crack'
+  s.add_dependency 'httpi', '2.4.2'
+  s.add_dependency 'hashie', '1.2.0'
+  s.add_dependency 'crack', '0.3.2'
 
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'vcr'
-  s.add_development_dependency 'fakeweb'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'simplecov-rcov'
+  s.add_development_dependency 'rspec', '2.10.0'
+  s.add_development_dependency 'vcr', '2.1.1'
+  s.add_development_dependency 'fakeweb', '1.3.0'
+  s.add_development_dependency 'simplecov', '0.6.4'
+  s.add_development_dependency 'simplecov-rcov', '0.2.3'
 
 end

--- a/spec/models/ping_spec.rb
+++ b/spec/models/ping_spec.rb
@@ -4,7 +4,7 @@ describe Sisow::Ping do
 
   it "should send a ping message" do
     VCR.use_cassette('ping') do
-      Sisow::Ping.send.class.should == String
+      Sisow::Ping.send.class.should == REXMLUtiliyNodeString
     end
   end
 


### PR DESCRIPTION
This pull updates the `httpi` and `crack` gems. I had some issues with other gems depending on newer versions of the sisow dependencies.

I've fixed the gem versions on the gemspec so future updating should be easier.