### PR TITLE
Fixed redirect issue

### DIFF
--- a/lib/sisow/api/request.rb
+++ b/lib/sisow/api/request.rb
@@ -4,7 +4,7 @@ module Sisow
   module Api
     class Request
 
-      BASE_URI = "http://www.sisow.nl/Sisow/iDeal/RestHandler.ashx"
+      BASE_URI = "https://www.sisow.nl/Sisow/iDeal/RestHandler.ashx"
 
       attr_writer :merchant_id,
                   :merchant_key

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -13,7 +13,7 @@ describe Sisow::Api::Request do
 
   it "should point to the base URI of the Sisow API" do
     request = Sisow::Api::Request.new
-    request.send(:base_uri).should == "http://www.sisow.nl/Sisow/iDeal/RestHandler.ashx"
+    request.send(:base_uri).should == "https://www.sisow.nl/Sisow/iDeal/RestHandler.ashx"
   end
 
   it "should perform properly" do


### PR DESCRIPTION
This pull fixes a redirect issue caused by using `http://` instead of `https://`. An error was raised because it did not expect a redirect or was able to handle one.